### PR TITLE
Fixed a bad reference to the SessionLog that was causing an error.

### DIFF
--- a/src/app/js/main.js
+++ b/src/app/js/main.js
@@ -493,6 +493,6 @@ Reveal.addEventListener('slidechanged', function (event) {
 const session = new TestSession();
 const cyCaller = new CyCaller()
 // Setting the logger callback to the session log.
-cyCaller.setLogCallBack(session.log)
+cyCaller.setLogCallBack((message,context) => session.log(message,context));
 setTimeout(() => { call(Reveal.getSlide(0)) }, 500)
 //log('Started Cytoscape Testing', 'init')


### PR DESCRIPTION
I used the ES6 syntax that allows us to use the context of the main.js file rather than the Cycaller's context. This format does not create a new `this` which is what the error was stemming from. 